### PR TITLE
fix(manager): change usage of ElCollapse and shrink height

### DIFF
--- a/src/views/manage/role/modules/role-search.vue
+++ b/src/views/manage/role/modules/role-search.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { $t } from '@/locales';
 import { enableStatusOptions } from '@/constants/business';
 import { translateOptions } from '@/utils/common';
 
 defineOptions({ name: 'RoleSearch' });
+
+const activeName = ref(['role-search']);
 
 interface Emits {
   (e: 'reset'): void;
@@ -25,7 +28,7 @@ function search() {
 
 <template>
   <ElCard class="card-wrapper">
-    <ElCollapse :default-expanded-names="['role-search']">
+    <ElCollapse v-model="activeName">
       <ElCollapseItem :title="$t('common.search')" name="role-search">
         <ElForm :model="model" label-position="right" :label-width="80">
           <ElRow :gutter="24">

--- a/src/views/manage/user/index.vue
+++ b/src/views/manage/user/index.vue
@@ -133,7 +133,7 @@ function edit(id: number) {
 </script>
 
 <template>
-  <div class="min-h-500px flex-col-stretch gap-16px overflow-hidden lt-sm:overflow-auto">
+  <div class="min-h-500px flex-col-stretch flex-shrink-0 gap-16px overflow-hidden lt-sm:overflow-auto">
     <UserSearch v-model:model="searchParams" @reset="resetSearchParams" @search="getDataByPage" />
     <ElCard class="sm:flex-1-hidden card-wrapper">
       <template #header>


### PR DESCRIPTION
there is two issue:

1. `role-search.vue` ElCollapse with default-expanded-names prop is not work. see [document here](https://element-plus.org/zh-CN/component/collapse.html#collapse-api). simply change it to v-model(Controlled mode)
2. `src/views/manage/user/index.vue` container default shrink is 1. so lead to children elements adapt to container height when the children elements total height larger than container element. Just change it to 0 for free height.

The screenshots are as follows. and reproduce link is here: [ElCollapse Usage](https://elp.soybeanjs.cn/manage/role), [Shrink Style](https://elp.soybeanjs.cn/manage/user)

![02e0bf0d4fc133a9d2d1520a1eed0030](https://github.com/user-attachments/assets/4e8a2d3e-c363-4a89-882f-fec688194d80)

![image](https://github.com/user-attachments/assets/5f9176fa-dcdb-460e-aa8c-c9520b136f83)
