### PR TITLE
style: improve the coverage of theme colors

### DIFF
--- a/src/styles/scss/element-plus.scss
+++ b/src/styles/scss/element-plus.scss
@@ -4,6 +4,7 @@ html:root,
 html.dark:root {
   @each $color in (primary, success, warning, info) {
     --el-color-#{$color}: rgb(var(--#{$color}-color));
+    --el-color-#{$color}-dark-2: rgb(var(--#{$color}-600-color));
     --el-color-#{$color}-light-3: rgb(var(--#{$color}-400-color));
     --el-color-#{$color}-light-5: rgb(var(--#{$color}-300-color));
     --el-color-#{$color}-light-7: rgb(var(--#{$color}-200-color));
@@ -11,6 +12,7 @@ html.dark:root {
   }
 
   --el-color-danger: rgb(var(--error-color));
+  --el-color-danger-dark-2: rgb(var(--error-600-color));
   --el-color-danger-light-3: rgb(var(--error-400-color));
   --el-color-danger-light-5: rgb(var(--error-300-color));
   --el-color-danger-light-7: rgb(var(--error-200-color));


### PR DESCRIPTION
完善主题色覆盖范围：

修改前（鼠标点击按钮时）：
<img width="522" height="632" alt="image" src="https://github.com/user-attachments/assets/3625bfed-5807-4c54-b9da-94e25d5555d9" />

修改后（鼠标点击按钮时）：
<img width="572" height="617" alt="image" src="https://github.com/user-attachments/assets/40dbf754-742e-463f-bd4f-3bb6853b568e" />
