### PR TITLE
fix(styles): resolve Vditor and wangEditor overlays being clipped by ElCard overflow

### DIFF
--- a/src/views/plugin/editor/markdown/index.vue
+++ b/src/views/plugin/editor/markdown/index.vue
@@ -40,7 +40,7 @@ onUnmounted(() => {
 
 <template>
   <div class="h-full">
-    <ElCard header="markdown插件" class="card-wrapper">
+    <ElCard header="markdown插件" class="card-wrapper" body-class="overflow-visible">
       <div ref="domRef"></div>
       <template #footer>
         <GithubLink link="https://github.com/Vanessa219/vditor" />

--- a/src/views/plugin/editor/quill/index.vue
+++ b/src/views/plugin/editor/quill/index.vue
@@ -26,7 +26,7 @@ onMounted(() => {
 
 <template>
   <div class="h-full">
-    <ElCard header="富文本插件" class="card-wrapper">
+    <ElCard header="富文本插件" class="card-wrapper" body-class="overflow-visible">
       <div ref="domRef" class="bg-white dark:bg-dark"></div>
       <template #footer>
         <GithubLink link="https://github.com/wangeditor-team/wangEditor" />


### PR DESCRIPTION
修复了编辑器鼠标悬浮菜单时提示文本显示不全的问题。

<img width="491" height="237" alt="image" src="https://github.com/user-attachments/assets/49799494-f0db-426a-84f9-77dad362ca02" />

<img width="277" height="185" alt="image" src="https://github.com/user-attachments/assets/0752fc70-6dc4-4566-9b22-899c9678473d" />

